### PR TITLE
Fix issue with .rosinstall for Ubuntu 20.04 ROS1 Noetic

### DIFF
--- a/.rosinstall
+++ b/.rosinstall
@@ -30,7 +30,7 @@
 - git:
     local-name: parrot_arsdk
     uri: https://github.com/antonellabarisic/parrot_arsdk.git
-    branch: noetic_dev
+    version: noetic_dev
 
 - git:
     local-name: odom_slam_sensor_fusion


### PR DESCRIPTION
The .rosinstall file, when using the current wstool version, will throw this error with the current .rosinstall:

```
ERROR in config: Unknown key branch in {'git': {'local-name': 'parrot_arsdk', 'uri': 'https://github.com/antonellabarisic/parrot_arsdk.git', 'branch': 'noetic_dev'}}
```

I went ahead and changed the `branch` key to `version` key, and that seemed to do the trick.